### PR TITLE
fix(ci): replaced echo with printf and added GPG key validation step

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -30,11 +30,24 @@ jobs:
       - name: 'Prepare Secrets'
         run: |
           mkdir -p '.secure_files'
-          echo "${GPG_PRIVATE_KEY}" > '.secure_files/autobump.asc'
-          echo "${PERSONAL_ACCESS_TOKEN}" > '.secure_files/github_access_token.key'
+          printf '%s' "${GPG_PRIVATE_KEY}" > '.secure_files/autobump.asc'
+          printf '%s' "${PERSONAL_ACCESS_TOKEN}" > '.secure_files/github_access_token.key'
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: 'Validate GPG Key'
+        run: |
+          if [ ! -s '.secure_files/autobump.asc' ]; then
+            echo 'ERROR: GPG key file is empty'
+            exit 1
+          fi
+          if ! head -1 '.secure_files/autobump.asc' | grep -q 'BEGIN PGP'; then
+            echo 'ERROR: GPG key file does not contain valid armored PGP data'
+            echo "First bytes: $(xxd -l 40 '.secure_files/autobump.asc')"
+            echo 'Ensure GPG_PRIVATE_KEY secret contains the output of: gpg --export-secret-key --armor <KEY_ID>'
+            exit 1
+          fi
 
       - name: 'Run Autobump'
         run: |

--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -42,9 +42,9 @@ jobs:
             echo 'ERROR: GPG key file is empty'
             exit 1
           fi
-          if ! head -1 '.secure_files/autobump.asc' | grep -q 'BEGIN PGP'; then
+          if ! grep -q 'BEGIN PGP' '.secure_files/autobump.asc' || ! grep -q 'END PGP' '.secure_files/autobump.asc'; then
             echo 'ERROR: GPG key file does not contain valid armored PGP data'
-            echo "First bytes: $(xxd -l 40 '.secure_files/autobump.asc')"
+            echo "GPG key file size (bytes): $(wc -c < '.secure_files/autobump.asc' || echo 'unknown')"
             echo 'Ensure GPG_PRIVATE_KEY secret contains the output of: gpg --export-secret-key --armor <KEY_ID>'
             exit 1
           fi


### PR DESCRIPTION
## Summary
- replaced `echo` with `printf '%s'` for writing secrets to disk, avoiding trailing newline ambiguity
- added a `Validate GPG Key` step that fails fast with a clear error message if the GPG key file is empty or does not contain valid armored PGP data

This addresses the `openpgp: invalid argument: no armored data found` errors seen in [run #22855725232](https://github.com/rios0rios0/autobump-automation/actions/runs/22855725232/job/66295405053).

## Test plan
- [ ] Trigger a manual workflow run and verify the validation step passes (or fails with actionable message if the secret is misconfigured)
- [ ] Verify autobump discover succeeds for repos that previously failed with GPG errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)