### PR TITLE
fix(workflow): replaced deprecated 'discover' command with 'run'

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch: # allows manual triggering of the workflow
 
 jobs:
-  batch:
-    name: 'autobump > batch'
+  run:
+    name: 'autobump > run'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout code'
@@ -53,5 +53,5 @@ jobs:
         run: |
           set -e
 
-          ./autobump discover
+          ./autobump run
           rm -rf '.secure_files'


### PR DESCRIPTION
## Summary

- changed job name from `batch` to `run` to match autoupdate-automation naming
- replaced deprecated `./autobump discover` with `./autobump run`

## Test plan

- [ ] Next scheduled run (or manual dispatch) confirms the pipeline works

🤖 Generated with [Claude Code](https://claude.com/claude-code)