### PR TITLE
fix(workflow): moved secrets cleanup to separate always-run step

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch: # allows manual triggering of the workflow
 
 jobs:
-  batch:
-    name: 'autobump > batch'
+  run:
+    name: 'autobump > run'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout code'
@@ -50,8 +50,8 @@ jobs:
           fi
 
       - name: 'Run Autobump'
-        run: |
-          set -e
+        run: ./autobump run
 
-          ./autobump discover
-          rm -rf '.secure_files'
+      - name: 'Cleanup Secrets'
+        if: always()
+        run: rm -rf '.secure_files'


### PR DESCRIPTION
## Summary

- split `rm -rf '.secure_files'` into a dedicated step with `if: always()` so secrets are cleaned up even when the tool exits non-zero
- also includes the `discover` -> `run` rename from #13 (supersedes it)

## Test plan

- [ ] Trigger a manual run and verify the cleanup step executes regardless of tool exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)