### PR TITLE
fix(workflow): changed GIT_USER to GIT_USER_NAME variable

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           cat <<-EOF >~/.gitconfig
           [user]
-              name = ${{ vars.GIT_USER }}
+              name = ${{ vars.GIT_USER_NAME }}
               email = ${{ vars.GIT_USER_EMAIL }}
               signingkey = ${{ vars.GIT_USER_SIGNINGKEY }}
           [push]


### PR DESCRIPTION
## Summary
- changed `GIT_USER` to `GIT_USER_NAME` to match the actual repository variable name, fixing potential empty git identity errors

## Test plan
- [ ] verify `GIT_USER_NAME` variable is set in repository settings
- [ ] trigger workflow manually and confirm no `empty ident name` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)