### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ This repository provides automated dependency and version management across mult
   3. Test binary execution (<1 second)
   4. Validate configuration syntax (<1 second)
 - **NEVER CANCEL** workflow operations - all steps complete in under 2 minutes
-- The actual GitHub Actions workflow runs daily at 13:00 UTC and can be manually triggered
+- The actual GitHub Actions workflow runs daily at 18:00 UTC and can be manually triggered
 
 ### Configuration Validation Steps
 - Validate YAML syntax: `yamllint .autobump.yaml`
@@ -61,9 +61,15 @@ This repository provides automated dependency and version management across mult
 ├── .github/
 │   ├── copilot-instructions.md  # This file
 │   ├── workflows/
-│   │   └── autobump.yaml    # Daily automation workflow
+│   │   ├── autobump.yaml        # Daily automation workflow
+│   │   ├── claude.yaml           # Claude Code assistant workflow
+│   │   └── claude-code-review.yaml # Claude Code PR review workflow
 │   ├── pull_request_template/
+│   │   ├── bump.md
+│   │   └── default.md
 │   └── pull_request_template.md
+├── CHANGELOG.md             # Release history
+├── CLAUDE.md                # Claude Code guidance
 ├── CONTRIBUTING.md          # Contribution guidelines
 ├── LICENSE                  # MIT License
 └── README.md                # Basic project description
@@ -75,6 +81,7 @@ This repository provides automated dependency and version management across mult
 Contains authentication tokens and provider configuration:
 ```yaml
 gpg_key_path: '.secure_files/autobump.asc'
+exclude_forks: true
 
 providers:
   - type: 'github'
@@ -85,15 +92,17 @@ providers:
 
 #### .github/workflows/autobump.yaml
 GitHub Actions workflow that:
-- Runs daily at 13:00 UTC (`cron: '0 13 * * *'`)
+- Runs daily at 18:00 UTC (`cron: '0 18 * * *'`)
 - Can be manually triggered via workflow_dispatch
 - Downloads latest Autobump binary via install script
 - Configures git with repository variables and secrets
-- Runs `./autobump discover`
+- Validates GPG key before running
+- Runs `./autobump run`
+- Cleans up secrets after completion
 
 ### Workflow Variables and Secrets Required
 The GitHub Actions workflow expects these repository **variables** (`vars.*`):
-- `GIT_USER` - Git commit author name
+- `GIT_USER_NAME` - Git commit author name
 - `GIT_USER_EMAIL` - Git commit author email
 - `GIT_USER_SIGNINGKEY` - GPG signing key ID
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- created `CLAUDE.md` with project guidance for Claude Code sessions
+
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to fix cron schedule (13:00 → 18:00 UTC), correct `GIT_USER` variable name to `GIT_USER_NAME`, update workflow command from `discover` to `run`, add `exclude_forks` to config example, and update repository structure tree
+
 ## [0.1.1] - 2026-03-30
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Configuration-only repository that runs [Autobump](https://github.com/rios0rios0/autobump) via GitHub Actions to version-bump repositories in the `rios0rios0` organization. No build process or source code.
+
+## Key Files
+
+- `.autobump.yaml` — main autobump configuration (providers, GPG key path, `exclude_forks`)
+- `.github/workflows/autobump.yaml` — daily workflow (cron `0 18 * * *`), runs `./autobump run`
+- `.github/workflows/claude.yaml` — Claude Code assistant workflow
+- `.github/workflows/claude-code-review.yaml` — Claude Code PR review workflow
+
+## Validation
+
+Validate YAML syntax: `yamllint .autobump.yaml`
+
+Test autobump locally:
+```bash
+curl -fsSL https://raw.githubusercontent.com/rios0rios0/autobump/main/install.sh | sh -s -- --install-dir . --force
+./autobump discover  # expects auth errors without real credentials
+```
+
+## Workflow Secrets and Variables
+
+Variables (`vars.*`): `GIT_USER_NAME`, `GIT_USER_EMAIL`, `GIT_USER_SIGNINGKEY`
+
+Secrets (`secrets.*`): `GPG_PRIVATE_KEY`, `PERSONAL_ACCESS_TOKEN`
+
+## Conventions
+
+- Follow [Development Guide](https://github.com/rios0rios0/guide/wiki) for coding standards and commit conventions.
+- Branch naming: `feat/`, `fix/`, `bump/x.x.x` for releases.
+- Always validate YAML after config changes.
+- Indent with tabs, UTF-8, LF line endings (see `.editorconfig`).


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.