### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,8 @@ This repository provides automated dependency and version management across mult
 │   ├── workflows/
 │   │   ├── autobump.yaml        # Daily automation workflow
 │   │   ├── claude.yaml           # Claude Code assistant workflow
-│   │   └── claude-code-review.yaml # Claude Code PR review workflow
+│   │   ├── claude-code-review.yaml # Claude Code PR review workflow
+│   │   └── release.yaml            # Creates Git tag on merge to main
 │   ├── pull_request_template/
 │   │   ├── bump.md
 │   │   └── default.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to document the new `release.yaml` workflow
+
 ## [0.2.0] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Configuration-only repository that runs [Autobump](https://github.com/rios0rios0
 - `.github/workflows/autobump.yaml` — daily workflow (cron `0 18 * * *`), runs `./autobump run`
 - `.github/workflows/claude.yaml` — Claude Code assistant workflow
 - `.github/workflows/claude-code-review.yaml` — Claude Code PR review workflow
+- `.github/workflows/release.yaml` — creates a Git tag on merge to `main` (delegates to `rios0rios0/pipelines`)
 
 ## Validation
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.