### PR TITLE
feat(orgs): added `medhub-tech` and `prefy` to the discovery scope

### DIFF
--- a/.autobump.yaml
+++ b/.autobump.yaml
@@ -6,3 +6,5 @@ providers:
     token: '.secure_files/github_access_token.key'
     organizations:
       - 'rios0rios0'
+      - 'medhub-tech'
+      - 'prefy'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,6 +89,8 @@ providers:
     token: '.secure_files/github_access_token.key'
     organizations:
       - 'rios0rios0'
+      - 'medhub-tech'
+      - 'prefy'
 ```
 
 #### .github/workflows/autobump.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added the `medhub-tech` and `prefy` organizations to the GitHub provider in `.autobump.yaml`, so repositories in both are discovered and version-bumped alongside `rios0rios0`
+
 ## [0.2.1] - 2026-05-19
 
 ### Changed


### PR DESCRIPTION
## :memo: Description

Autobump only queries the organization names listed under `providers[].organizations` — it never enumerates everything the token can reach. Since `.autobump.yaml` listed only `rios0rios0`, repositories in `medhub-tech` and `prefy` were never discovered or version-bumped.

This adds both organizations to the existing GitHub provider block, reusing the single `PERSONAL_ACCESS_TOKEN` secret.

## :warning: Follow-up required on the token

The config change alone is not sufficient — `secrets.PERSONAL_ACCESS_TOKEN` must actually reach both organizations:

- It must be a **classic** PAT with the `repo` scope. A fine-grained PAT is bound to a single resource owner and will not see the other two organizations regardless of this config.
- If either organization enforces SAML SSO, the token must be **SSO-authorized** for each one.
- Both organizations must permit PAT access (Settings → Personal access tokens), and the token's account needs write permission to push branches and open pull requests.

If a single token cannot cover all three, the alternative is one provider block per organization, each with its own token file — which also requires extra secrets in the `Prepare Secrets` step of `.github/workflows/autobump.yaml`.

## :vertical_traffic_light: Quality checklist

- [ ] Are the pipeline and tests passing?