### PR TITLE
fix(ci): ran autobump once per owner with its own fine-grained PAT

### DIFF
--- a/.autobump.yaml
+++ b/.autobump.yaml
@@ -1,10 +1,17 @@
+# Global settings shared by every owner.
+#
+# The `providers` block is deliberately absent. A GitHub fine-grained PAT is bound to a
+# single resource owner, so one token can never span `rios0rios0`, `medhub-tech` and
+# `prefy`. `.github/workflows/autobump.yaml` runs one matrix job per owner and appends a
+# single-owner `providers` block to a copy of this file at runtime, which keeps the owner
+# list and its per-owner secret declared in exactly one place: the workflow matrix.
+#
+# To run AutoBump locally against one owner, append the same block by hand:
+#
+#   providers:
+#     - type: 'github'
+#       token: '.secure_files/github_access_token.key'
+#       organizations:
+#         - 'rios0rios0'
 gpg_key_path: '.secure_files/autobump.asc'
 exclude_forks: true
-
-providers:
-  - type: 'github'
-    token: '.secure_files/github_access_token.key'
-    organizations:
-      - 'rios0rios0'
-      - 'medhub-tech'
-      - 'prefy'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,10 @@ This repository provides automated dependency and version management across mult
 ### Configuration Management
 - The main configuration file is `.autobump.yaml` containing:
   - GPG key path for commit signing
-  - A `providers` list with provider type, token path, and target organizations
+  - `exclude_forks`
+  - **No** `providers` list. A fine-grained PAT is bound to a single resource owner, so the
+    workflow runs one matrix job per owner and appends a single-owner `providers` block to a
+    copy of this file at runtime
 - Validate configuration syntax: `yamllint .autobump.yaml` -- takes <1 second
   - WARNING: yamllint will report missing document start "---" which is acceptable
 
@@ -79,28 +82,36 @@ This repository provides automated dependency and version management across mult
 ### Key Configuration Files
 
 #### .autobump.yaml
-Contains authentication tokens and provider configuration:
+Holds only the settings shared by every owner:
 ```yaml
 gpg_key_path: '.secure_files/autobump.asc'
 exclude_forks: true
+```
 
+The `Render Owner Configuration` step copies it to `${RUNNER_TEMP}/autobump.yaml` and appends
+the owner currently being processed, producing the file that `./autobump run --config` reads:
+```yaml
 providers:
   - type: 'github'
     token: '.secure_files/github_access_token.key'
     organizations:
-      - 'rios0rios0'
       - 'medhub-tech'
-      - 'prefy'
 ```
 
 #### .github/workflows/autobump.yaml
 GitHub Actions workflow that:
 - Runs daily at 18:00 UTC (`cron: '0 18 * * *'`)
 - Can be manually triggered via workflow_dispatch
+- Fans out into one job per owner via `strategy.matrix.owner`, each entry pairing an owner
+  name with the secret holding that owner's fine-grained PAT. `fail-fast: false` keeps one
+  owner's broken token from cancelling the others
 - Downloads latest Autobump binary via install script
 - Configures git with repository variables and secrets
-- Validates GPG key before running
-- Runs `./autobump run`
+- Validates the GPG key and the owner's token before running
+- Renders a single-owner config, then runs `./autobump run --config`
+- Asserts the owner was actually reached: AutoBump logs discovery failures and still exits 0,
+  so the `Assert Owner Was Reached` step fails the job when the log contains
+  `Failed to discover repos in` or no `Discovery complete:` summary
 - Cleans up secrets after completion
 
 ### Workflow Variables and Secrets Required
@@ -111,7 +122,15 @@ The GitHub Actions workflow expects these repository **variables** (`vars.*`):
 
 The GitHub Actions workflow expects these repository **secrets** (`secrets.*`):
 - `GPG_PRIVATE_KEY` - GPG private key for commit signing
-- `PERSONAL_ACCESS_TOKEN` - GitHub personal access token for API authentication
+- `PERSONAL_ACCESS_TOKEN` - fine-grained PAT for the `rios0rios0` account
+- `MEDHUB_TECH_ACCESS_TOKEN` - fine-grained PAT for the `medhub-tech` organization
+- `PREFY_ACCESS_TOKEN` - fine-grained PAT for the `prefy` organization
+
+A fine-grained PAT is bound to a single resource owner, so one token cannot cover all three.
+Every token's lifetime must be **366 days or less**: both organizations reject longer-lived
+fine-grained tokens with `403 ... forbids access via a fine-grained personal access tokens if
+the token's lifetime is greater than 366 days`. To add an owner, add a matrix entry and its
+secret — no other file changes.
 
 ### Expected Timing
 - **apt-get update && install**: 30-60 seconds
@@ -132,7 +151,7 @@ The GitHub Actions workflow expects these repository **secrets** (`secrets.*`):
 
 ### Integration Points
 - Main Autobump tool repository: https://github.com/rios0rios0/autobump
-- Target GitHub organization managed by providers config: `rios0rios0`
+- Owners managed by the workflow matrix: `rios0rios0`, `medhub-tech`, `prefy`
 - GitHub Actions for automation
 - GPG signing for commit verification
 

--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -5,8 +5,22 @@ on:
 
 jobs:
   run:
-    name: 'autobump > run'
+    name: 'autobump > run (${{ matrix.owner.name }})'
     runs-on: 'ubuntu-latest'
+    strategy:
+      # a fine-grained PAT is bound to a single resource owner, so one token cannot span
+      # every owner and each one carries its own failure modes (expiry, revoked grant,
+      # organization policy). `fail-fast: false` keeps a broken token for one owner from
+      # cancelling the others
+      fail-fast: false
+      matrix:
+        owner:
+          - name: 'rios0rios0'
+            secret: 'PERSONAL_ACCESS_TOKEN'
+          - name: 'medhub-tech'
+            secret: 'MEDHUB_TECH_ACCESS_TOKEN'
+          - name: 'prefy'
+            secret: 'PREFY_ACCESS_TOKEN'
     steps:
       - name: 'Checkout code'
         uses: 'actions/checkout@v6'
@@ -31,12 +45,12 @@ jobs:
         run: |
           mkdir -p '.secure_files'
           printf '%s' "${GPG_PRIVATE_KEY}" > '.secure_files/autobump.asc'
-          printf '%s' "${PERSONAL_ACCESS_TOKEN}" > '.secure_files/github_access_token.key'
+          printf '%s' "${OWNER_ACCESS_TOKEN}" > '.secure_files/github_access_token.key'
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          OWNER_ACCESS_TOKEN: ${{ secrets[matrix.owner.secret] }}
 
-      - name: 'Validate GPG Key'
+      - name: 'Validate Secrets'
         run: |
           if [ ! -s '.secure_files/autobump.asc' ]; then
             echo 'ERROR: GPG key file is empty'
@@ -48,9 +62,58 @@ jobs:
             echo 'Ensure GPG_PRIVATE_KEY secret contains the output of: gpg --export-secret-key --armor <KEY_ID>'
             exit 1
           fi
+          if [ ! -s '.secure_files/github_access_token.key' ]; then
+            echo "ERROR: the '${OWNER_SECRET}' secret is empty or not set"
+            echo "Every owner needs its own fine-grained PAT, and '${OWNER_NAME}' reads it from '${OWNER_SECRET}'"
+            echo 'The token lifetime must be 366 days or less, otherwise the organizations reject it'
+            exit 1
+          fi
+        env:
+          OWNER_NAME: ${{ matrix.owner.name }}
+          OWNER_SECRET: ${{ matrix.owner.secret }}
+
+      - name: 'Render Owner Configuration'
+        run: |
+          cp '.autobump.yaml' "${RUNNER_TEMP}/autobump.yaml"
+          cat >>"${RUNNER_TEMP}/autobump.yaml" <<EOF
+
+          providers:
+            - type: 'github'
+              token: '.secure_files/github_access_token.key'
+              organizations:
+                - '${OWNER_NAME}'
+          EOF
+          cat "${RUNNER_TEMP}/autobump.yaml"
+        env:
+          OWNER_NAME: ${{ matrix.owner.name }}
 
       - name: 'Run Autobump'
-        run: ./autobump run
+        run: |
+          set -o pipefail
+          ./autobump run --config "${RUNNER_TEMP}/autobump.yaml" 2>&1 | tee "${RUNNER_TEMP}/autobump.log"
+
+      - name: 'Assert Owner Was Reached'
+        run: |
+          # AutoBump logs a discovery failure and still exits 0, so a revoked or
+          # policy-blocked token would otherwise surface as a green run that silently
+          # processed nothing. Fail this owner's job instead of hiding the gap
+          if grep -qE 'Failed to (discover repos in|initialize provider)' "${RUNNER_TEMP}/autobump.log"; then
+            echo "::error::AutoBump could not reach '${OWNER_NAME}', so none of its repositories were processed"
+            grep -E 'Failed to (discover repos in|initialize provider)' "${RUNNER_TEMP}/autobump.log" >&2
+            exit 1
+          fi
+          if ! grep -q 'Discovery complete:' "${RUNNER_TEMP}/autobump.log"; then
+            echo "::error::AutoBump produced no discovery summary for '${OWNER_NAME}'"
+            exit 1
+          fi
+          errors="$(sed -e 's/\x1b\[[0-9;]*m//g' "${RUNNER_TEMP}/autobump.log" \
+            | sed -n 's/.*Discovery complete: [0-9]\{1,\} repos processed, \([0-9]\{1,\}\) errors.*/\1/p' \
+            | tail -1)"
+          if [ -n "${errors}" ] && [ "${errors}" -gt 0 ]; then
+            echo "::warning::AutoBump reported ${errors} per-repository error(s) for '${OWNER_NAME}'"
+          fi
+        env:
+          OWNER_NAME: ${{ matrix.owner.name }}
 
       - name: 'Cleanup Secrets'
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `medhub-tech` and `prefy` never being version-bumped: a single fine-grained PAT is bound to one resource owner, so the shared `PERSONAL_ACCESS_TOKEN` was rejected by both organizations with `403 ... forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 366 days`, and AutoBump logged the discovery failure but still exited `0` — every run since the two owners were added reported success while silently processing only `rios0rios0`
+- fixed the workflow reporting success when an owner could not be reached, by adding an `Assert Owner Was Reached` step that fails the job when the run log contains a discovery failure or no `Discovery complete:` summary
+
+### Changed
+
+- changed the daily workflow to fan out into one job per owner via `strategy.matrix.owner`, each job authenticating with that owner's own fine-grained PAT (`PERSONAL_ACCESS_TOKEN`, `MEDHUB_TECH_ACCESS_TOKEN`, `PREFY_ACCESS_TOKEN`) and running with `fail-fast: false` so one broken token no longer cancels the other owners
+- changed `.autobump.yaml` to hold only the settings shared by every owner; the `providers` block is now rendered per job from the matrix entry, keeping the owner list and its secret declared in exactly one place
+
 ## [0.3.0] - 2026-08-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Configuration-only repository that runs [Autobump](https://github.com/rios0rios0/autobump) via GitHub Actions to version-bump repositories in the `rios0rios0` organization. No build process or source code.
+Configuration-only repository that runs [Autobump](https://github.com/rios0rios0/autobump) via GitHub Actions to version-bump repositories owned by `rios0rios0`, `medhub-tech` and `prefy`. No build process or source code.
 
 ## Key Files
 
-- `.autobump.yaml` — main autobump configuration (providers, GPG key path, `exclude_forks`)
-- `.github/workflows/autobump.yaml` — daily workflow (cron `0 18 * * *`), runs `./autobump run`
+- `.autobump.yaml` — global autobump configuration (GPG key path, `exclude_forks`). It carries **no** `providers` block: the workflow appends a single-owner one per matrix job
+- `.github/workflows/autobump.yaml` — daily workflow (cron `0 18 * * *`), one matrix job per owner, runs `./autobump run --config` against the rendered single-owner config
 - `.github/workflows/claude.yaml` — Claude Code assistant workflow
 - `.github/workflows/claude-code-review.yaml` — Claude Code PR review workflow
 - `.github/workflows/release.yaml` — creates a Git tag on merge to `main` (delegates to `rios0rios0/pipelines`)
@@ -28,7 +28,13 @@ curl -fsSL https://raw.githubusercontent.com/rios0rios0/autobump/main/install.sh
 
 Variables (`vars.*`): `GIT_USER_NAME`, `GIT_USER_EMAIL`, `GIT_USER_SIGNINGKEY`
 
-Secrets (`secrets.*`): `GPG_PRIVATE_KEY`, `PERSONAL_ACCESS_TOKEN`
+Secrets (`secrets.*`): `GPG_PRIVATE_KEY`, plus one fine-grained PAT per owner —
+`PERSONAL_ACCESS_TOKEN` (`rios0rios0`), `MEDHUB_TECH_ACCESS_TOKEN` (`medhub-tech`), `PREFY_ACCESS_TOKEN` (`prefy`).
+
+A fine-grained PAT is bound to a single resource owner, so one token cannot cover all three.
+Each token's lifetime must be **366 days or less** — both organizations reject longer-lived
+fine-grained tokens with a 403. Adding an owner means adding a matrix entry in the workflow
+and its matching secret; nothing else changes.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ GitHub Actions automation workflow that runs [AutoBump](https://github.com/rios0
 
 Take a look at the [Autobump repository](https://github.com/rios0rios0/autobump) for more information about how the tool works.
 
+## Configuration
+
+The daily workflow runs one job per owner. Each owner needs its own fine-grained PAT, because a
+GitHub fine-grained token is bound to a single resource owner and cannot span several:
+
+| Owner         | Secret                     |
+|---------------|----------------------------|
+| `rios0rios0`  | `PERSONAL_ACCESS_TOKEN`    |
+| `medhub-tech` | `MEDHUB_TECH_ACCESS_TOKEN` |
+| `prefy`       | `PREFY_ACCESS_TOKEN`       |
+
+Every token's lifetime must be **366 days or less** — the organizations reject longer-lived
+fine-grained tokens with a `403`. Commit signing additionally needs the `GPG_PRIVATE_KEY` secret
+and the `GIT_USER_NAME`, `GIT_USER_EMAIL` and `GIT_USER_SIGNINGKEY` variables.
+
+To cover another owner, add an entry to `strategy.matrix.owner` in
+[`.github/workflows/autobump.yaml`](.github/workflows/autobump.yaml) and create its secret.
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Problem

`medhub-tech` and `prefy` have never been version-bumped since they were added on 2026-08-13. A GitHub fine-grained PAT is bound to a **single** resource owner, so the shared `PERSONAL_ACCESS_TOKEN` was rejected by both organizations:

```
403 The 'medhub-tech' organization forbids access via a fine-grained personal
access tokens if the token's lifetime is greater than 366 days.
```

AutoBump logs that discovery failure and **still exits `0`**, so every run reported success while silently processing only `rios0rios0` — the 2026-08-16 run ended with `Discovery complete: 69 repos processed, 2 errors` and a green check.

## Change

- the daily workflow fans out into one job per owner via `strategy.matrix.owner`, each entry pairing an owner with the secret holding its token. `fail-fast: false` keeps one broken token from cancelling the others
- `.autobump.yaml` now holds only the settings shared by every owner; the `providers` block is rendered per job from the matrix entry, so the owner list and its secret are declared in exactly one place
- a new `Assert Owner Was Reached` step fails the job when the log contains `Failed to discover repos in` or no `Discovery complete:` summary — the silent-green case cannot recur

## Required before merge

Two new secrets, each a fine-grained PAT with a lifetime of **366 days or less**:

| Owner         | Secret                     |
|---------------|----------------------------|
| `rios0rios0`  | `PERSONAL_ACCESS_TOKEN` (existing) |
| `medhub-tech` | `MEDHUB_TECH_ACCESS_TOKEN` |
| `prefy`       | `PREFY_ACCESS_TOKEN`       |

## Validation

- rendered config executed locally from the workflow's own `run` block and parsed — produces a valid single-owner `providers` block
- `Assert Owner Was Reached` tested against the real 2026-08-16 run log (fails as intended) plus clean, ANSI-coloured, per-repo-error, and missing-summary cases
- all `run:` scripts pass `shellcheck -S warning` clean

## :vertical_traffic_light: Quality checklist

- [ ] Are the pipeline and tests passing?