### PR TITLE
fix(ci): corrected the `medhub-tech` secret name to `MEDHUB_ACCESS_TOKEN`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,7 +123,7 @@ The GitHub Actions workflow expects these repository **variables** (`vars.*`):
 The GitHub Actions workflow expects these repository **secrets** (`secrets.*`):
 - `GPG_PRIVATE_KEY` - GPG private key for commit signing
 - `PERSONAL_ACCESS_TOKEN` - fine-grained PAT for the `rios0rios0` account
-- `MEDHUB_TECH_ACCESS_TOKEN` - fine-grained PAT for the `medhub-tech` organization
+- `MEDHUB_ACCESS_TOKEN` - fine-grained PAT for the `medhub-tech` organization
 - `PREFY_ACCESS_TOKEN` - fine-grained PAT for the `prefy` organization
 
 A fine-grained PAT is bound to a single resource owner, so one token cannot cover all three.

--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -18,7 +18,7 @@ jobs:
           - name: 'rios0rios0'
             secret: 'PERSONAL_ACCESS_TOKEN'
           - name: 'medhub-tech'
-            secret: 'MEDHUB_TECH_ACCESS_TOKEN'
+            secret: 'MEDHUB_ACCESS_TOKEN'
           - name: 'prefy'
             secret: 'PREFY_ACCESS_TOKEN'
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
-- changed the daily workflow to fan out into one job per owner via `strategy.matrix.owner`, each job authenticating with that owner's own fine-grained PAT (`PERSONAL_ACCESS_TOKEN`, `MEDHUB_TECH_ACCESS_TOKEN`, `PREFY_ACCESS_TOKEN`) and running with `fail-fast: false` so one broken token no longer cancels the other owners
+- changed the daily workflow to fan out into one job per owner via `strategy.matrix.owner`, each job authenticating with that owner's own fine-grained PAT (`PERSONAL_ACCESS_TOKEN`, `MEDHUB_ACCESS_TOKEN`, `PREFY_ACCESS_TOKEN`) and running with `fail-fast: false` so one broken token no longer cancels the other owners
 - changed `.autobump.yaml` to hold only the settings shared by every owner; the `providers` block is now rendered per job from the matrix entry, keeping the owner list and its secret declared in exactly one place
 
 ## [0.3.0] - 2026-08-13

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/rios0rios0/autobump/main/install.sh
 Variables (`vars.*`): `GIT_USER_NAME`, `GIT_USER_EMAIL`, `GIT_USER_SIGNINGKEY`
 
 Secrets (`secrets.*`): `GPG_PRIVATE_KEY`, plus one fine-grained PAT per owner —
-`PERSONAL_ACCESS_TOKEN` (`rios0rios0`), `MEDHUB_TECH_ACCESS_TOKEN` (`medhub-tech`), `PREFY_ACCESS_TOKEN` (`prefy`).
+`PERSONAL_ACCESS_TOKEN` (`rios0rios0`), `MEDHUB_ACCESS_TOKEN` (`medhub-tech`), `PREFY_ACCESS_TOKEN` (`prefy`).
 
 A fine-grained PAT is bound to a single resource owner, so one token cannot cover all three.
 Each token's lifetime must be **366 days or less** — both organizations reject longer-lived

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub fine-grained token is bound to a single resource owner and cannot span se
 | Owner         | Secret                     |
 |---------------|----------------------------|
 | `rios0rios0`  | `PERSONAL_ACCESS_TOKEN`    |
-| `medhub-tech` | `MEDHUB_TECH_ACCESS_TOKEN` |
+| `medhub-tech` | `MEDHUB_ACCESS_TOKEN` |
 | `prefy`       | `PREFY_ACCESS_TOKEN`       |
 
 Every token's lifetime must be **366 days or less** — the organizations reject longer-lived


### PR DESCRIPTION
## Problem

#26 wired the `medhub-tech` matrix entry to `MEDHUB_TECH_ACCESS_TOKEN`, but the secret actually configured on this repository is `MEDHUB_ACCESS_TOKEN`:

```
$ gh secret list --repo rios0rios0/autobump-automation
CLAUDE_CODE_OAUTH_TOKEN
GPG_PRIVATE_KEY
MEDHUB_ACCESS_TOKEN        <-- actual
PERSONAL_ACCESS_TOKEN
PREFY_ACCESS_TOKEN
```

On the next 18:00 UTC run the `medhub-tech` job would resolve its token to empty and stop at `Validate Secrets` with `ERROR: the 'MEDHUB_TECH_ACCESS_TOKEN' secret is empty or not set`. `rios0rios0` and `prefy` are unaffected — `fail-fast: false` keeps them running — so the damage is limited to `medhub-tech` still being skipped, which is exactly what #26 set out to fix.

Worth noting the failure mode is at least loud now: before #26 this would have been another green run.

## Change

One-word rename in the matrix entry, plus the four documentation files that quoted the old name. The `[Unreleased]` changelog entry from #26 is corrected in place rather than appended to, since it never shipped under the wrong name.

## Validation

Parsed the workflow and asserted every `strategy.matrix.owner` secret resolves to one of the three names `gh secret list` reports.

## :vertical_traffic_light: Quality checklist

- [ ] Are the pipeline and tests passing?