### PR TITLE
fix(ci): repointed the renamed medhub organization

### DIFF
--- a/.autobump.yaml
+++ b/.autobump.yaml
@@ -1,7 +1,7 @@
 # Global settings shared by every owner.
 #
 # The `providers` block is deliberately absent. A GitHub fine-grained PAT is bound to a
-# single resource owner, so one token can never span `rios0rios0`, `medhub-tech` and
+# single resource owner, so one token can never span `rios0rios0`, `medhub-life` and
 # `prefy`. `.github/workflows/autobump.yaml` runs one matrix job per owner and appends a
 # single-owner `providers` block to a copy of this file at runtime, which keeps the owner
 # list and its per-owner secret declared in exactly one place: the workflow matrix.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,7 @@ providers:
   - type: 'github'
     token: '.secure_files/github_access_token.key'
     organizations:
-      - 'medhub-tech'
+      - 'medhub-life'
 ```
 
 #### .github/workflows/autobump.yaml
@@ -123,7 +123,7 @@ The GitHub Actions workflow expects these repository **variables** (`vars.*`):
 The GitHub Actions workflow expects these repository **secrets** (`secrets.*`):
 - `GPG_PRIVATE_KEY` - GPG private key for commit signing
 - `PERSONAL_ACCESS_TOKEN` - fine-grained PAT for the `rios0rios0` account
-- `MEDHUB_ACCESS_TOKEN` - fine-grained PAT for the `medhub-tech` organization
+- `MEDHUB_ACCESS_TOKEN` - fine-grained PAT for the `medhub-life` organization
 - `PREFY_ACCESS_TOKEN` - fine-grained PAT for the `prefy` organization
 
 A fine-grained PAT is bound to a single resource owner, so one token cannot cover all three.
@@ -151,7 +151,7 @@ secret — no other file changes.
 
 ### Integration Points
 - Main Autobump tool repository: https://github.com/rios0rios0/autobump
-- Owners managed by the workflow matrix: `rios0rios0`, `medhub-tech`, `prefy`
+- Owners managed by the workflow matrix: `rios0rios0`, `medhub-life`, `prefy`
 - GitHub Actions for automation
 - GPG signing for commit verification
 

--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -17,7 +17,7 @@ jobs:
         owner:
           - name: 'rios0rios0'
             secret: 'PERSONAL_ACCESS_TOKEN'
-          - name: 'medhub-tech'
+          - name: 'medhub-life'
             secret: 'MEDHUB_ACCESS_TOKEN'
           - name: 'prefy'
             secret: 'PREFY_ACCESS_TOKEN'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the `medhub-tech` matrix leg in `.github/workflows/autobump.yaml` targeting an organization that no longer exists: it was renamed to `medhub-life`, so every API call against the old name returned `404` and that owner's repositories were never version-bumped — `fail-fast: false` kept the other owners green, so the run reported success while one third of the fleet was skipped; the `MEDHUB_ACCESS_TOKEN` secret name is unchanged, only the owner it addresses
+
 ## [0.3.1] - 2026-08-24
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Configuration-only repository that runs [Autobump](https://github.com/rios0rios0/autobump) via GitHub Actions to version-bump repositories owned by `rios0rios0`, `medhub-tech` and `prefy`. No build process or source code.
+Configuration-only repository that runs [Autobump](https://github.com/rios0rios0/autobump) via GitHub Actions to version-bump repositories owned by `rios0rios0`, `medhub-life` and `prefy`. No build process or source code.
 
 ## Key Files
 
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/rios0rios0/autobump/main/install.sh
 Variables (`vars.*`): `GIT_USER_NAME`, `GIT_USER_EMAIL`, `GIT_USER_SIGNINGKEY`
 
 Secrets (`secrets.*`): `GPG_PRIVATE_KEY`, plus one fine-grained PAT per owner —
-`PERSONAL_ACCESS_TOKEN` (`rios0rios0`), `MEDHUB_ACCESS_TOKEN` (`medhub-tech`), `PREFY_ACCESS_TOKEN` (`prefy`).
+`PERSONAL_ACCESS_TOKEN` (`rios0rios0`), `MEDHUB_ACCESS_TOKEN` (`medhub-life`), `PREFY_ACCESS_TOKEN` (`prefy`).
 
 A fine-grained PAT is bound to a single resource owner, so one token cannot cover all three.
 Each token's lifetime must be **366 days or less** — both organizations reject longer-lived

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub fine-grained token is bound to a single resource owner and cannot span se
 | Owner         | Secret                     |
 |---------------|----------------------------|
 | `rios0rios0`  | `PERSONAL_ACCESS_TOKEN`    |
-| `medhub-tech` | `MEDHUB_ACCESS_TOKEN` |
+| `medhub-life` | `MEDHUB_ACCESS_TOKEN` |
 | `prefy`       | `PREFY_ACCESS_TOKEN`       |
 
 Every token's lifetime must be **366 days or less** — the organizations reject longer-lived


### PR DESCRIPTION
## Why

The `medhub-tech` organization was renamed to `medhub-life`. Every API call against the old name returns `404`:

```
$ gh api orgs/medhub-tech
{"message":"Not Found","status":"404"}
```

`.github/workflows/autobump.yaml` still names it in `strategy.matrix.owner`, so that leg has been failing on every scheduled run and no repository in that organization has been version-bumped. Because the matrix sets `fail-fast: false`, the other two owners kept passing — the workflow looked healthy while silently covering two thirds of the intended fleet.

Found while auditing the same bug in [`config-automation#65`](https://github.com/rios0rios0/config-automation/pull/65), which fixes the three scheduled workflows there. This repository and `autoupdate-automation` share the same per-owner secret names, so they carried the same stale owner.

## What changed

- `strategy.matrix.owner` leg renamed `medhub-tech` → `medhub-life`. The `MEDHUB_ACCESS_TOKEN` secret name is unchanged; only the owner it addresses. A fine-grained PAT follows its organization through a rename, so the existing token should keep working — worth confirming on the next scheduled run.
- Same rename in `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md` and the `.autobump.yaml` header comment.
- `CHANGELOG.md` history is left untouched: those entries record what was true when they were written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)