### PR TITLE
feat(skills): added a Copilot code-review skill

### DIFF
--- a/.changes/unreleased/1787760511213797531-08b4.yaml
+++ b/.changes/unreleased/1787760511213797531-08b4.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added a tailored `code-review` skill under `.github/skills/` so GitHub Copilot reviews changes against the [rios0rios0/guide](https://github.com/rios0rios0/guide/wiki) standards and this repository''s own load-bearing invariants'
+time: '2026-08-26T16:08:31.213712162Z'

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: code-review
+description: "Review pull requests and diffs in autobump-automation — the scheduled workflows that run autobump across the estate — against the rios0rios0/guide standards, with extra weight on the blast radius of the project list, secret scoping, and SHA-pinned actions. Use when reviewing a PR, a branch, or staged changes here."
+---
+
+# Code review — `autobump-automation`
+
+`autobump-automation` is configuration, not code: `.autobump.yaml` and a set of GitHub Actions workflows that run [autobump](https://github.com/rios0rios0/autobump) on a schedule to cut releases across many repositories. Every entry in the configuration is a repository this automation will write to.
+
+## When to use this skill
+
+Use it whenever you are asked to review a pull request, a diff, a branch, or staged changes
+in this repository — and before opening a pull request of your own, as a self-check. It is a
+**review** skill: it produces findings, not commits.
+
+## Source of truth
+
+The canonical engineering standards live in the
+**[rios0rios0/guide wiki](https://github.com/rios0rios0/guide/wiki)**. This file is a
+repo-tailored index into that guide plus the rules that only apply here. Precedence, highest
+first:
+
+1. This repository's `.github/copilot-instructions.md`, `CLAUDE.md`, and `CONTRIBUTING.md` —
+   they describe *this* codebase and its load-bearing invariants.
+2. The **rios0rios0/guide** wiki — the shared standard.
+3. General language idiom.
+
+When the guide and a general convention disagree, the guide wins. When this file and the
+guide disagree, the guide wins and this file should be corrected in the same pull request.
+
+### Guide pages that apply here
+
+| Topic | Page |
+|-------|------|
+| YAML Conventions — `.yaml`, single quotes, unquoted scalars | [YAML](https://github.com/rios0rios0/guide/wiki/YAML) |
+| Git Flow — branches, commits, SemVer, breaking changes | [Git-Flow](https://github.com/rios0rios0/guide/wiki/Git-Flow) |
+| Documentation & Change Control — changelog and docs discipline | [Documentation-&-Change-Control](https://github.com/rios0rios0/guide/wiki/Documentation-&-Change-Control) |
+| CHANGELOG Formatting — capitalisation and backticks | [CHANGELOG-Formatting](https://github.com/rios0rios0/guide/wiki/CHANGELOG-Formatting) |
+| Security — OWASP checklist, secret hygiene, SAST | [Security](https://github.com/rios0rios0/guide/wiki/Security) |
+| CI & CD — pipeline stages and the local quality gates | [CI-&-CD](https://github.com/rios0rios0/guide/wiki/CI-&-CD) |
+| Code Style — baseline naming and the operations vocabulary | [Code-Style](https://github.com/rios0rios0/guide/wiki/Code-Style) |
+
+## How to run the review
+
+1. **Establish the range.** Resolve the default branch with
+   `git symbolic-ref refs/remotes/origin/HEAD` (strip `refs/remotes/origin/`; fall back to `main`),
+   then read the diff with `git diff <default>...HEAD` and the file list with
+   `git diff <default>...HEAD --name-only`.
+2. **Read whole files, not just hunks.** A hunk cannot show a layering violation, a missing
+   test, or a duplicated helper. Open every changed file in full, plus the files it imports
+   from the layer below.
+3. **Check the change set as a unit** — not only the code. A change that alters behaviour,
+   configuration, or architecture is incomplete without its changelog entry and its
+   documentation update, and that omission is a finding in its own right.
+4. **Map every finding to a rule.** Each finding must name the rule it breaks and link the
+   guide page (or the repository file) that states it. A comment that cannot be traced to a
+   rule is a suggestion, not a defect — label it as such.
+5. **Report, do not rewrite.** Produce the review in the output format below. Only edit files
+   when the request explicitly asks for fixes.
+
+## What matters most in `autobump-automation`
+
+These are the checks that catch real defects in this repository. Work through
+them before the generic ones.
+
+- **Every project added to `.autobump.yaml` is a repository this job will commit to, push to, and open pull requests against.** A wrong entry, or a wrong branch, means unwanted commits in someone else's repository. Adding one is a behavioural change that needs a changelog entry.
+- **Tokens are scoped per owner.** A fine-grained PAT is bound to a single resource owner, so a workflow that hands one owner's token to another owner's leg fails with a confusing 404. Check the secret name matches the owner.
+- **Secrets never reach a log or a URL.** No `echo` of a token, no token interpolated into a remote URL that gets printed, and no `set -x` around an authenticated command.
+- **Actions are pinned to a full commit SHA** with a trailing `# vX.Y.Z` comment, and bumps land across every workflow in one commit.
+- **A schedule change is a cost and rate-limit change.** Moving a cron to run more often multiplies API calls across the whole estate — say why in the pull-request description.
+- **The tool lives elsewhere.** Logic belongs in [`autobump`](https://github.com/rios0rios0/autobump), not in a shell step here — a workflow that grows its own bumping logic will drift from the tool.
+- **Failures must stay visible.** `continue-on-error` on a step that decides whether a release happened turns a broken run into a green one.
+- YAML uses `.yaml`, single-quoted strings, and unquoted booleans and numbers.
+
+### Commands a reviewer should be able to quote
+
+```bash
+# configuration repository — validate by dispatching the workflow manually
+gh workflow run autobump.yaml --ref <branch>
+```
+
+### YAML
+
+See [YAML Conventions](https://github.com/rios0rios0/guide/wiki/YAML). The extension is `.yaml`, never `.yml`. String values are
+single-quoted; double quotes appear only where interpolation or an escape needs them;
+booleans and numbers are never quoted. This applies to workflows, compose files, manifests,
+and YAML blocks inside Markdown.
+
+## Tests
+
+There is no test suite. Verification is a manual `workflow_dispatch` run on the branch, with the result read from the run log before merging.
+
+## Documentation and change control
+
+See [Documentation & Change Control](https://github.com/rios0rios0/guide/wiki/Documentation-&-Change-Control) and
+[CHANGELOG Formatting](https://github.com/rios0rios0/guide/wiki/CHANGELOG-Formatting).
+
+This repository uses **chlog fragments**. `CHANGELOG.md` is generated and is never edited by
+hand.
+
+- Every change ships a fragment created with `chlog new --kind <Kind> --body "…"`, staged in
+  the **same commit** as the code. Kinds: `Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`, `Security`.
+- A backward-incompatible change to the public interface additionally carries `--breaking`.
+  The kind alone never triggers a major bump.
+- A hand-edited `CHANGELOG.md`, or a code change with no fragment under
+  `.changes/unreleased/`, is a **Critical** finding — `chlog check` fails the build for it.
+- Fragment bodies start with a lowercase verb in simple past tense, capitalise proper nouns
+  (GitHub, Go, Docker), and wrap code identifiers and versions in backticks.
+- `README.md` is updated whenever usage, setup, configuration, or architecture changes;
+  `.github/copilot-instructions.md` and `CLAUDE.md` whenever the workflow, commands, or
+  structure changes. Documentation and code ship in one commit.
+
+## Git Flow and pull-request hygiene
+
+See [Git Flow](https://github.com/rios0rios0/guide/wiki/Git-Flow) and [Merge Guide](https://github.com/rios0rios0/guide/wiki/Merge-Guide).
+
+- Branch names are `feat/`, `fix/`, `refactor/`, `chore/`, `test/`, or `docs/` followed by a
+  ticket ID or a short slug — `feat/TICKET-000`, `fix/input-mask`.
+- Commit subjects are `type(SCOPE): message`: simple past tense (`added`, `fixed`, `changed`,
+  `removed`), lowercase first word, no trailing period, code identifiers in backticks.
+- Branches are synchronised with `git rebase`, never `git merge`. A merge commit from the
+  default branch inside a feature branch is a finding.
+- Breaking changes are flagged in **three** places: the commit footer
+  (`**BREAKING CHANGE:** …`), the changelog, and the pull-request description. One or two of
+  the three is not enough.
+- Versions follow [SemVer](https://semver.org/): MAJOR for incompatible changes, MINOR for
+  features, PATCH for fixes.
+
+## Security
+
+See [Security](https://github.com/rios0rios0/guide/wiki/Security).
+
+- **No hard-coded secrets.** API keys, tokens, passwords, and private keys belong in
+  environment variables or a secret manager — never in source, tests, fixtures, or the
+  changelog. A secret that reaches a commit must be rotated, not merely deleted.
+- **Never write a PEM header sentinel or a realistic key shape into a fixture**
+  (`ghp_…`, `sk-…`, `AKIA…`, `xoxb-…`, JWT-shaped strings, or the dashed `BEGIN …` banners).
+  Gitleaks matches the shape, not the value, so a placeholder that merely *looks* like a
+  credential fails the pipeline. Use inert placeholders such as `fixture-token-placeholder`.
+- **Suppressions must be justified.** Entries in `.gitleaksignore`, `.trivyignore`,
+  `.semgrepignore`, or `.codeql-false-positives` need a fingerprint, a dated comment, and a
+  reason. A suppression added to silence a real finding is a Critical.
+- Validate and sanitise every external input; use parameterised queries; apply least
+  privilege; keep secrets out of logs.
+- Dependency manifest changes are reviewed for new transitive vulnerabilities. When a fix
+  exists, bump the version rather than suppressing the finding.
+
+## What not to flag
+
+A review that raises noise gets ignored. Do not report these:
+
+- The absence of application code — this repository is configuration and workflows.
+- Anything the guide does not require and this file does not list, unless it is a genuine correctness or security defect — say so plainly and label it a Suggestion.
+
+## Review output format
+
+```
+## Code review: <branch or PR>
+
+### Critical (must fix before merge)
+- `path/to/file.ext:LINE` — <what is wrong> — violates <rule> (<guide page or repo file>)
+
+### Warning (should fix)
+- `path/to/file.ext:LINE` — <what is wrong> — violates <rule>
+
+### Suggestion (optional)
+- `path/to/file.ext:LINE` — <improvement>
+
+### Change-control checklist
+- [ ] Changelog entry present for every behavioural change
+- [ ] `README.md` updated if usage, setup, or architecture changed
+- [ ] `.github/copilot-instructions.md` and `CLAUDE.md` updated if the workflow, commands, or structure changed
+- [ ] Commit messages follow `type(SCOPE): message` in simple past tense
+- [ ] Breaking changes flagged in the commit footer, the changelog, and the PR description
+
+### Verdict: APPROVE / REQUEST CHANGES
+<one paragraph: the blocking findings, or why the change is ready>
+```
+
+## Severity
+
+| Severity       | Use for                                                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------|
+| **Critical**   | Broken dependency direction, a leaked secret, an injection or authentication flaw, a missing changelog entry, a banned mock library, a load-bearing invariant broken, a test deleted rather than fixed. |
+| **Warning**    | Naming that departs from the guide, a missing test for a new branch of logic, an unexplained magic value, a stale README or instructions file, a `switch` that should be a map. |
+| **Suggestion** | Readability, consistency with neighbouring modules, and performance ideas that no rule mandates.                                     |
+
+Rank findings most severe first, and state plainly when nothing blocks the merge — an empty
+Critical section is a valid, useful review.


### PR DESCRIPTION
## What

Adds `.github/skills/code-review/SKILL.md` — a [GitHub Copilot agent skill](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
that Copilot discovers automatically for anyone working in this repository.

> Review pull requests and diffs in autobump-automation — the scheduled workflows that run autobump across the estate — against the rios0rios0/guide standards, with extra weight on the blast radius of the project list, secret scoping, and SHA-pinned actions. Use when reviewing a PR, a branch, or staged changes here.

## Why

`.github/copilot-instructions.md` already tells Copilot **how this code works**. This skill covers
the other half — **how a change is judged**: it teaches Copilot to review pull requests, diffs, and
staged changes against the standards in [rios0rios0/guide](https://github.com/rios0rios0/guide/wiki)
instead of against generic best practice.

## What is in it

- **A precedence rule** — this repository's `.github/copilot-instructions.md`, `CLAUDE.md`, and
  `CONTRIBUTING.md` first; then the guide; then general language idiom.
- **A linked index of the 7 guide pages that apply here**, so every finding can cite the rule
  it comes from.
- **A repository-specific checklist first** — 8 checks covering the load-bearing invariants of
  *this* codebase, because those are what catch real defects.
- **The shared guide rules** — layering and dependency direction, language conventions, BDD tests and
  the mock-library ban, chlog fragments, Git Flow and the three-place breaking-change rule, secret
  hygiene and the SAST gates.
- **A "what not to flag" section**, so the review stays signal rather than noise.
- **A fixed output format and severity scale**, so reviews read the same way across every repository.

## Notes

- The skill is tailored per repository: the invariants, commands, layout, and known non-issues are
  different in each one.
- The change is recorded as a chlog fragment under `.changes/unreleased/`; `CHANGELOG.md` is
  untouched, as it is generated.
- No behaviour, build, or CI change — one Markdown file plus one changelog fragment.

Part of a set adding the same skill, individually tailored, to every non-fork `rios0rios0`
repository.
